### PR TITLE
Add splash screen and make it the app entry

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'screens/signup/signup_start.dart';
 import 'screens/login.dart';
+import 'screens/splash.dart';
 
 // 경민이 파일이랑 연결
 // import 'screens/home/home.dart';
 
 // 앱 시작 지점
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
   runApp(const MyApp()); // 앱 전체를 MyApp으로 감싼다.
 }
 
@@ -22,7 +26,7 @@ class MyApp extends StatelessWidget {
         colorScheme: ColorScheme.fromSeed(seedColor: Colors.white),
         fontFamily: 'Pretendard',
       ),
-      home: const SignupStartScreen(), // 어플 실행하면 회원가입 화면 호출
+      home: const SplashScreen(), // 어플 실행하면 스플래쉬 화면 호출
       // 화면 연결
       routes: {
         '/signup': (context) => const SignupStartScreen(),

--- a/lib/screens/login.dart
+++ b/lib/screens/login.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../services/auth_service.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -10,6 +11,7 @@ class LoginScreen extends StatefulWidget {
 class _LoginScreenState extends State<LoginScreen> {
   final TextEditingController emailController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
+  final AuthService _authService = AuthService();
 
   bool isEmailFilled = false;
   bool isPasswordFilled = false;
@@ -121,8 +123,18 @@ class _LoginScreenState extends State<LoginScreen> {
 
                   ElevatedButton(
                     onPressed: isFormFilled
-                        ? () {
-                            // 로그인 처리
+                        ? () async {
+                            try {
+                              await _authService.signIn(
+                                emailController.text.trim(),
+                                passwordController.text.trim(),
+                              );
+                              // TODO: navigate to the next screen after login
+                            } catch (e) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(content: Text('로그인 실패: ' + e.toString())),
+                              );
+                            }
                           }
                         : null,
                     style: ButtonStyle(

--- a/lib/screens/signup/signup_detail.dart
+++ b/lib/screens/signup/signup_detail.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import '../../services/auth_service.dart';
+
+class SignupDetailScreen extends StatefulWidget {
+  final String email;
+  const SignupDetailScreen({Key? key, required this.email}) : super(key: key);
+
+  @override
+  State<SignupDetailScreen> createState() => _SignupDetailScreenState();
+}
+
+class _SignupDetailScreenState extends State<SignupDetailScreen> {
+  final TextEditingController passwordController = TextEditingController();
+  final AuthService _authService = AuthService();
+
+  @override
+  void dispose() {
+    passwordController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('비밀번호 설정')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          children: [
+            TextField(
+              controller: passwordController,
+              decoration: const InputDecoration(labelText: '비밀번호'),
+              obscureText: true,
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: () async {
+                final password = passwordController.text.trim();
+                if (password.isEmpty) return;
+                try {
+                  await _authService.signUp(widget.email, password);
+                  if (mounted) {
+                    Navigator.popUntil(context, ModalRoute.withName('/login'));
+                  }
+                } catch (e) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('회원가입 실패: ' + e.toString())),
+                  );
+                }
+              },
+              child: const Text('회원가입 완료'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/signup/signup_start.dart
+++ b/lib/screens/signup/signup_start.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/gestures.dart';
 import 'package:photo_town/screens/login.dart';
+import 'signup_detail.dart';
 
 
 // StatefulWidget을 상속받아 회원가입 시작 화면 정의 시작
@@ -106,9 +107,18 @@ class _SignupStartScreenState extends State<SignupStartScreen> {
                   const SizedBox(height: 15), // 간격 설정
                   // 이메일 확인 버튼
                   ElevatedButton(
-                    onPressed: () {
-                      // 이메일 확인 처리
-                    },
+                    onPressed: hasText
+                        ? () {
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (context) => SignupDetailScreen(
+                                  email: emailController.text.trim(),
+                                ),
+                              ),
+                            );
+                          }
+                        : null,
                     style: ElevatedButton.styleFrom(
                       backgroundColor: hasText
                           ? Color(0xFFDBEFC4)

--- a/lib/screens/splash.dart
+++ b/lib/screens/splash.dart
@@ -1,0 +1,35 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'login.dart';
+
+class SplashScreen extends StatefulWidget {
+  const SplashScreen({super.key});
+
+  @override
+  State<SplashScreen> createState() => _SplashScreenState();
+}
+
+class _SplashScreenState extends State<SplashScreen> {
+  @override
+  void initState() {
+    super.initState();
+    Timer(const Duration(seconds: 2), () {
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(builder: (context) => const LoginScreen()),
+      );
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      backgroundColor: Colors.white,
+      body: Center(
+        child: Text(
+          '사진 동네',
+          style: TextStyle(fontSize: 30, fontWeight: FontWeight.bold),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,0 +1,27 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class AuthService {
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final FirebaseFirestore _db = FirebaseFirestore.instance;
+
+  Future<UserCredential> signIn(String email, String password) {
+    return _auth.signInWithEmailAndPassword(email: email, password: password);
+  }
+
+  Future<UserCredential> signUp(String email, String password) async {
+    final credential = await _auth.createUserWithEmailAndPassword(
+      email: email,
+      password: password,
+    );
+    await _db.collection('users').doc(credential.user!.uid).set({
+      'email': email,
+      'createdAt': FieldValue.serverTimestamp(),
+    });
+    return credential;
+  }
+
+  Future<void> signOut() => _auth.signOut();
+
+  Stream<User?> get userChanges => _auth.userChanges();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,6 +34,9 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  firebase_core: ^2.27.0
+  firebase_auth: ^4.19.0
+  cloud_firestore: ^4.15.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a simple splash screen that routes to `LoginScreen`
- use `SplashScreen` as the home page
- integrate Firebase authentication for login and signup

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9d171d4c832aae4ee8f68a442fe3