### PR TITLE
Add authentication and location functionality

### DIFF
--- a/lib/screens/home.dart
+++ b/lib/screens/home.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:geolocator/geolocator.dart';
+import '../services/location_service.dart';
+
+class HomeScreen extends StatefulWidget {
+  const HomeScreen({super.key});
+
+  @override
+  State<HomeScreen> createState() => _HomeScreenState();
+}
+
+class _HomeScreenState extends State<HomeScreen> {
+  final LocationService _locationService = LocationService();
+  Position? _position;
+  String? _error;
+
+  Future<void> _loadLocation() async {
+    setState(() {
+      _error = null;
+    });
+    try {
+      final pos = await _locationService.getCurrentPosition();
+      setState(() {
+        _position = pos;
+      });
+    } catch (e) {
+      setState(() {
+        _error = e.toString();
+      });
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('홈')),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            ElevatedButton(
+              onPressed: _loadLocation,
+              child: const Text('현재 위치 가져오기'),
+            ),
+            const SizedBox(height: 20),
+            if (_position != null)
+              Text('위도: ${_position!.latitude}, 경도: ${_position!.longitude}'),
+            if (_error != null)
+              Text(
+                _error!,
+                style: const TextStyle(color: Colors.red),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/login.dart
+++ b/lib/screens/login.dart
@@ -1,4 +1,6 @@
 import 'package:flutter/material.dart';
+import '../services/auth_service.dart';
+import 'home.dart';
 
 class LoginScreen extends StatefulWidget {
   const LoginScreen({super.key});
@@ -8,6 +10,7 @@ class LoginScreen extends StatefulWidget {
 }
 
 class _LoginScreenState extends State<LoginScreen> {
+  final AuthService _authService = AuthService();
   final TextEditingController emailController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
 
@@ -122,8 +125,25 @@ class _LoginScreenState extends State<LoginScreen> {
 
                   ElevatedButton(
                     onPressed: isFormFilled
-                        ? () {
-                            // 로그인 처리
+                        ? () async {
+                            try {
+                              await _authService.signIn(
+                                emailController.text,
+                                passwordController.text,
+                              );
+                              if (context.mounted) {
+                                Navigator.pushReplacement(
+                                  context,
+                                  MaterialPageRoute(builder: (context) => const HomeScreen()),
+                                );
+                              }
+                            } catch (e) {
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(content: Text('로그인 실패: ' + e.toString())),
+                                );
+                              }
+                            }
                           }
                         : null,
                     style: ButtonStyle(

--- a/lib/screens/signup/signup_detail.dart
+++ b/lib/screens/signup/signup_detail.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:photo_town/widgets/id_input.dart';
+import '../../services/auth_service.dart';
 import 'package:photo_town/widgets/pw_input.dart';
 import 'package:photo_town/widgets/terms_checkbox.dart';
 
@@ -14,6 +15,7 @@ class SignupDetailScreen extends StatefulWidget {
 class _SignupDetailScreenState extends State<SignupDetailScreen> {
   final TextEditingController idController = TextEditingController();
   final TextEditingController passwordController = TextEditingController();
+  final AuthService _authService = AuthService();
   final TextEditingController passwordConfirmController =
       TextEditingController();
   final TextEditingController nicknameController = TextEditingController();
@@ -442,7 +444,24 @@ class _SignupDetailScreenState extends State<SignupDetailScreen> {
                       return;
                     }
 
-                    // 가입하기 로직
+                    try {
+                      await _authService.signUp(
+                        emailController.text,
+                        passwordController.text,
+                      );
+                      if (context.mounted) {
+                        Navigator.pop(context);
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          const SnackBar(content: Text('회원가입 완료')),
+                        );
+                      }
+                    } catch (e) {
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text('회원가입 실패: ' + e.toString())),
+                        );
+                      }
+                    }
                   },
                   style: ElevatedButton.styleFrom(
                     backgroundColor: isSignupEnabled

--- a/lib/services/location_service.dart
+++ b/lib/services/location_service.dart
@@ -1,0 +1,24 @@
+import 'package:geolocator/geolocator.dart';
+
+class LocationService {
+  Future<Position> getCurrentPosition() async {
+    bool serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      return Future.error('GPS 비활성화됨');
+    }
+
+    LocationPermission permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        return Future.error('위치 권한 거부됨');
+      }
+    }
+
+    if (permission == LocationPermission.deniedForever) {
+      return Future.error('위치 권한 영구 거부됨');
+    }
+
+    return Geolocator.getCurrentPosition();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,7 @@ dependencies:
   firebase_core: ^2.27.0
   firebase_auth: ^4.19.0
   cloud_firestore: ^4.15.0
+  geolocator: ^11.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- wire login screen up to `AuthService` and show errors
- connect signup flow to backend and show success/failure
- add `LocationService` and simple `HomeScreen` for fetching location
- include geolocator package

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68590b58fc4c832aaca8b648e3363d5a